### PR TITLE
wip: (1/2) 🚧 date-fns@3.0.6 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ import utcToZonedTime from 'date-fns-tz/utcToZonedTime'
 ### v1.0.8 (12 October 2019)
 
 - [BUGFIX] Not losing milliseconds when converting time zones. (#25)
-- [BUGFIX] Fix missing `_lib/convertToFP/index.js`. (#20)
+- [BUGFIX] Fix missing `_lib/convertToFP.js`. (#20)
 - [UPGRADE] Upgrade dependencies and match the `date-fns@2` build config.
 
 ### v1.0.6 (2 February 2019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,7 +139,7 @@ import utcToZonedTime from 'date-fns-tz/utcToZonedTime'
 ### v1.0.8 (12 October 2019)
 
 - [BUGFIX] Not losing milliseconds when converting time zones. (#25)
-- [BUGFIX] Fix missing `_lib/convertToFP.js`. (#20)
+- [BUGFIX] Fix missing `_lib/convertToFP/index.js`. (#20)
 - [UPGRADE] Upgrade dependencies and match the `date-fns@2` build config.
 
 ### v1.0.6 (2 February 2019)

--- a/docs/OptionsWithTZ.js
+++ b/docs/OptionsWithTZ.js
@@ -64,7 +64,7 @@
  * @example
  * // For 15 December 12345 AD, represent the start of the week in Esperanto,
  * // if the first day of the week is Monday:
- * var eoLocale = require('date-fns/locale').eo
+ * var eoLocale = require('date-fns/locale/eo')
  * var options = {
  *   weekStartsOn: 1,
  *   additionalDigits: 1,

--- a/docs/OptionsWithTZ.js
+++ b/docs/OptionsWithTZ.js
@@ -64,7 +64,7 @@
  * @example
  * // For 15 December 12345 AD, represent the start of the week in Esperanto,
  * // if the first day of the week is Monday:
- * var eoLocale = require('date-fns/locale/eo')
+ * var eoLocale = require('date-fns/locale').eo
  * var options = {
  *   weekStartsOn: 1,
  *   additionalDigits: 1,

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     ]
   },
   "peerDependencies": {
-    "date-fns": ">=2.0.0"
+    "date-fns": ">=3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",
@@ -139,7 +139,7 @@
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-preset-power-assert": "^3.0.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^2.23.0",
+    "date-fns": "^3.0.0",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^7.2.0",
     "flow-bin": "^0.143.1",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-preset-power-assert": "^3.0.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^3.0.0",
+    "date-fns": "^3.0.3",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^7.2.0",
     "flow-bin": "^0.143.1",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     ]
   },
   "peerDependencies": {
-    "date-fns": ">=3.0.0"
+    "date-fns": ">=3.0.4"
   },
   "devDependencies": {
     "@babel/cli": "^7.15.4",
@@ -139,7 +139,7 @@
     "babel-plugin-add-module-exports": "^1.0.4",
     "babel-preset-power-assert": "^3.0.0",
     "cross-env": "^7.0.3",
-    "date-fns": "^3.0.3",
+    "date-fns": "^3.0.4",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^7.2.0",
     "flow-bin": "^0.143.1",

--- a/scripts/build/fp.js
+++ b/scripts/build/fp.js
@@ -27,7 +27,7 @@ function getFPFn(resultFnName, initialFnName, arity) {
   return [generatedAutomaticallyMessage]
     .concat('')
     .concat(`import fn from '../../${initialFnName}/index.js'`)
-    .concat(`import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'`)
+    .concat(`import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'`)
     .concat('')
     .concat(`var ${resultFnName} = convertToFP(fn, ${arity})`)
     .concat('')

--- a/src/_lib/assign/index.js
+++ b/src/_lib/assign/index.js
@@ -1,0 +1,15 @@
+export default function assign(target, dirtyObject) {
+  if (target == null) {
+    throw new TypeError('assign requires that input parameter not be null or undefined')
+  }
+
+  dirtyObject = dirtyObject || {}
+
+  for (var property in dirtyObject) {
+    if (Object.prototype.hasOwnProperty.call(dirtyObject, property)) {
+      target[property] = dirtyObject[property]
+    }
+  }
+
+  return target
+}

--- a/src/_lib/cloneObject/index.js
+++ b/src/_lib/cloneObject/index.js
@@ -1,0 +1,5 @@
+import assign from '../assign/index.js'
+
+export default function cloneObject(dirtyObject) {
+  return (0, assign)({}, dirtyObject)
+}

--- a/src/_lib/toInteger/index.js
+++ b/src/_lib/toInteger/index.js
@@ -1,0 +1,13 @@
+export default function toInteger(dirtyNumber) {
+  if (dirtyNumber === null || dirtyNumber === true || dirtyNumber === false) {
+    return NaN
+  }
+
+  var number = Number(dirtyNumber)
+
+  if (isNaN(number)) {
+    return number
+  }
+
+  return number < 0 ? Math.ceil(number) : Math.floor(number)
+}

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -1,4 +1,4 @@
-import dateFnsFormat from 'date-fns/format/index.js'
+import { format as dateFnsFormat } from 'date-fns/format.js'
 import formatters from './formatters/index.js'
 import toDate from '../toDate/index.js'
 
@@ -303,7 +303,7 @@ var tzFormattingTokensRegExp = /([xXOz]+)|''|'(''|[^'])+('|$)/g
  *
  * @example
  * // Represent 2 July 2014 in Esperanto:
- * import { eoLocale } from 'date-fns/locale/eo'
+ * import { eoLocale } from 'date-fns/locale'
  * var result = format(new Date(2014, 6, 2), "do 'de' MMMM yyyy", {
  *   locale: eoLocale
  * })

--- a/src/format/index.js
+++ b/src/format/index.js
@@ -303,7 +303,7 @@ var tzFormattingTokensRegExp = /([xXOz]+)|''|'(''|[^'])+('|$)/g
  *
  * @example
  * // Represent 2 July 2014 in Esperanto:
- * import { eoLocale } from 'date-fns/locale'
+ * import { eoLocale } from 'date-fns/locale/eo'
  * var result = format(new Date(2014, 6, 2), "do 'de' MMMM yyyy", {
  *   locale: eoLocale
  * })

--- a/src/format/test.js
+++ b/src/format/test.js
@@ -3,7 +3,7 @@
 
 import assert from 'power-assert'
 import format from '.'
-import enGB from 'date-fns/locale/en-GB'
+import { enGB } from 'date-fns/locale'
 import utcToZonedTime from '../utcToZonedTime'
 
 describe('format', function () {

--- a/src/formatInTimeZone/index.js
+++ b/src/formatInTimeZone/index.js
@@ -1,4 +1,4 @@
-import cloneObject from 'date-fns/_lib/cloneObject/index.js'
+import cloneObject from '../_lib/cloneObject/index.js'
 import format from '../format/index.js'
 import utcToZonedTime from '../utcToZonedTime/index.js'
 

--- a/src/fp/format/index.js
+++ b/src/fp/format/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../format/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var format = convertToFP(fn, 2)
 

--- a/src/fp/formatInTimeZone/index.js
+++ b/src/fp/formatInTimeZone/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../formatInTimeZone/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var formatInTimeZone = convertToFP(fn, 3)
 

--- a/src/fp/formatInTimeZoneWithOptions/index.js
+++ b/src/fp/formatInTimeZoneWithOptions/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../formatInTimeZone/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var formatInTimeZoneWithOptions = convertToFP(fn, 4)
 

--- a/src/fp/formatWithOptions/index.js
+++ b/src/fp/formatWithOptions/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../format/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var formatWithOptions = convertToFP(fn, 3)
 

--- a/src/fp/getTimezoneOffset/index.js
+++ b/src/fp/getTimezoneOffset/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../getTimezoneOffset/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var getTimezoneOffset = convertToFP(fn, 2)
 

--- a/src/fp/toDate/index.js
+++ b/src/fp/toDate/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../toDate/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var toDate = convertToFP(fn, 1)
 

--- a/src/fp/toDateWithOptions/index.js
+++ b/src/fp/toDateWithOptions/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../toDate/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var toDateWithOptions = convertToFP(fn, 2)
 

--- a/src/fp/utcToZonedTime/index.js
+++ b/src/fp/utcToZonedTime/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../utcToZonedTime/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var utcToZonedTime = convertToFP(fn, 2)
 

--- a/src/fp/utcToZonedTimeWithOptions/index.js
+++ b/src/fp/utcToZonedTimeWithOptions/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../utcToZonedTime/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var utcToZonedTimeWithOptions = convertToFP(fn, 3)
 

--- a/src/fp/zonedTimeToUtc/index.js
+++ b/src/fp/zonedTimeToUtc/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../zonedTimeToUtc/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var zonedTimeToUtc = convertToFP(fn, 2)
 

--- a/src/fp/zonedTimeToUtcWithOptions/index.js
+++ b/src/fp/zonedTimeToUtcWithOptions/index.js
@@ -1,7 +1,7 @@
 // This file is generated automatically by `scripts/build/fp.js`. Please, don't change it.
 
 import fn from '../../zonedTimeToUtc/index.js'
-import convertToFP from 'date-fns/fp/_lib/convertToFP/index.js'
+import { convertToFP } from 'date-fns/fp/_lib/convertToFP.js'
 
 var zonedTimeToUtcWithOptions = convertToFP(fn, 3)
 

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -1,5 +1,5 @@
-import toInteger from 'date-fns/_lib/toInteger/index.js'
-import getTimezoneOffsetInMilliseconds from 'date-fns/_lib/getTimezoneOffsetInMilliseconds/index.js'
+import { toInteger } from '../_lib/toInteger/index.js'
+import { getTimezoneOffsetInMilliseconds } from 'date-fns/_lib/getTimezoneOffsetInMilliseconds.js'
 import tzParseTimezone from '../_lib/tzParseTimezone/index.js'
 import tzPattern from '../_lib/tzPattern/index.js'
 

--- a/src/toDate/index.js
+++ b/src/toDate/index.js
@@ -1,4 +1,4 @@
-import { toInteger } from '../_lib/toInteger/index.js'
+import toInteger from '../_lib/toInteger/index.js'
 import { getTimezoneOffsetInMilliseconds } from 'date-fns/_lib/getTimezoneOffsetInMilliseconds.js'
 import tzParseTimezone from '../_lib/tzParseTimezone/index.js'
 import tzPattern from '../_lib/tzPattern/index.js'

--- a/src/utcToZonedTime/test.js
+++ b/src/utcToZonedTime/test.js
@@ -1,5 +1,5 @@
 import assert from 'power-assert'
-import format from 'date-fns/format'
+import { format } from 'date-fns/format'
 import utcToZonedTime from '.'
 import newDateUTC from '../_lib/newDateUTC'
 

--- a/src/zonedTimeToUtc/index.js
+++ b/src/zonedTimeToUtc/index.js
@@ -1,4 +1,4 @@
-import cloneObject from 'date-fns/_lib/cloneObject/index.js'
+import cloneObject from '../_lib/cloneObject/index.js'
 import toDate from '../toDate/index.js'
 import tzPattern from '../_lib/tzPattern/index.js'
 import tzParseTimezone from '../_lib/tzParseTimezone/index.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,7 +2710,7 @@ __metadata:
     babel-plugin-add-module-exports: ^1.0.4
     babel-preset-power-assert: ^3.0.0
     cross-env: ^7.0.3
-    date-fns: ^3.0.0
+    date-fns: ^3.0.3
     eslint: ^7.11.0
     eslint-config-prettier: ^7.2.0
     flow-bin: ^0.143.1
@@ -2742,10 +2742,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"date-fns@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "date-fns@npm:3.0.0"
-  checksum: 16d570c6a3b1c6caed67982bb7831daf666cd84be3150733abcd21cadd7757e8f05225c86edd3fe5a9d3a45cd61886ddd505aadfc937c400272a6ff5d8e163c3
+"date-fns@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "date-fns@npm:3.0.3"
+  checksum: 1bc19abb9432d136b7e80b900795d4e19291c5028cf03d38314b22a5ced0047ce739a69905c24b03afbc10dbde74dc34df389e52df12eae0ee46aa42c30dbbc4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,7 +2710,7 @@ __metadata:
     babel-plugin-add-module-exports: ^1.0.4
     babel-preset-power-assert: ^3.0.0
     cross-env: ^7.0.3
-    date-fns: ^3.0.3
+    date-fns: ^3.0.4
     eslint: ^7.11.0
     eslint-config-prettier: ^7.2.0
     flow-bin: ^0.143.1
@@ -2738,14 +2738,14 @@ __metadata:
     webpack: ^4.41.1
     webpack-cli: ^3.1.2
   peerDependencies:
-    date-fns: ">=3.0.0"
+    date-fns: ">=3.0.4"
   languageName: unknown
   linkType: soft
 
-"date-fns@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "date-fns@npm:3.0.3"
-  checksum: 1bc19abb9432d136b7e80b900795d4e19291c5028cf03d38314b22a5ced0047ce739a69905c24b03afbc10dbde74dc34df389e52df12eae0ee46aa42c30dbbc4
+"date-fns@npm:^3.0.4":
+  version: 3.0.5
+  resolution: "date-fns@npm:3.0.5"
+  checksum: 67bd4f90276cda5b668abb470a9f216b2b76e646eaf2c976324ab238283e252d79d1089d922074d43bd18122f82d2c15f61c40d5fde0822671f6b63099ca33ab
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2710,7 +2710,7 @@ __metadata:
     babel-plugin-add-module-exports: ^1.0.4
     babel-preset-power-assert: ^3.0.0
     cross-env: ^7.0.3
-    date-fns: ^2.23.0
+    date-fns: ^3.0.0
     eslint: ^7.11.0
     eslint-config-prettier: ^7.2.0
     flow-bin: ^0.143.1
@@ -2738,14 +2738,14 @@ __metadata:
     webpack: ^4.41.1
     webpack-cli: ^3.1.2
   peerDependencies:
-    date-fns: ">=2.0.0"
+    date-fns: ">=3.0.0"
   languageName: unknown
   linkType: soft
 
-"date-fns@npm:^2.23.0":
-  version: 2.23.0
-  resolution: "date-fns@npm:2.23.0"
-  checksum: 5b23cf7f08a27d0c1633e81304c95ac2bacb1160d86a25d36c40c84853796e442e597a4d75acec3f0920a71f3a65dd55b37565d356fa3fb4c2345225df42d930
+"date-fns@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "date-fns@npm:3.0.0"
+  checksum: 16d570c6a3b1c6caed67982bb7831daf666cd84be3150733abcd21cadd7757e8f05225c86edd3fe5a9d3a45cd61886ddd505aadfc937c400272a6ff5d8e163c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Just trying to walk-through and see _where_ some updates may need to be made.

Drafting here as I think the current ESM module work and looping for the `fp` stuff may be better handled by someone with more innerworking knowledge of `date-fns-tz`.

- [x] `assign` function port from `date-fns@2`
- [x] `cloneObject` function port from `date-fns@2`
- [x] `toInteger` function port from `date-fns@2`
- [x] move to named exports instead of default
- [ ] probably a lot more 🤣   

